### PR TITLE
Added quit functionality

### DIFF
--- a/lib/ipcInterface.js
+++ b/lib/ipcInterface.js
@@ -23,6 +23,9 @@ var ipcInterface = function(options) {
 	// intialize the event emitter
 	eventEmitter.call(this);
 
+	// initiliaze flag for checking exit status
+        this.exiting = false;
+
 	// socket object
 	this.socket = new net.Socket();
 
@@ -44,7 +47,11 @@ var ipcInterface = function(options) {
 			console.log("Lost connection to socket. Atemping to reconnect");
 		}		
 		// properly close the connection
-		this.socket.end()
+		this.socket.end();
+                // if exiting then do not reconnect socket
+                if (this.exiting) {
+                         return;
+                }
 		// reconnect
 		this.socket.connect({path: this.options.socket}, function() {
 			if(this.options.verbose || this.options.debug){

--- a/lib/mpv/_controls.js
+++ b/lib/mpv/_controls.js
@@ -21,6 +21,13 @@ var controls = {
 	stop: function() {
 		this.socket.command("stop", []);
 	},
+	// quit
+	quit: function() {
+                // set exiting flags when quit is called
+		this.exiting = true;
+                this.socket.exiting = true;
+		this.socket.command("quit", []);
+	},
 	// volume control values 0-100
 	volume: function(value) {
 		this.socket.setProperty("volume", value);

--- a/lib/mpv/mpv.js
+++ b/lib/mpv/mpv.js
@@ -27,7 +27,8 @@ function mpv(options, mpv_args){
 
 	// intialize the event emitter
 	eventEmitter.call(this);
-
+	// initiliaze flag for checking exit status
+	this.exiting = false;
 
 	// set the ipc command according to the mpv version
 	var ipcCommand = "";
@@ -197,6 +198,11 @@ function mpv(options, mpv_args){
 
 	// if mpv crashes restart it again
 	this.mpvPlayer.on('close', function respawn() {
+                // if exiting then no need to respawn
+		if (this.exiting) {
+			return;
+		}
+
 		if(this.options.debug){
 			console.log("MPV Player seems to have died. Restarting...");
 		}


### PR DESCRIPTION
Not sure if this is honestly the best way to handle this.

Added quit function and added settings so the socket won't reconnect and the mpv process won't respawn.
The Mpv instance is no longer valid and can no longer be used after quit is called.

This was brought on because I've had issues with the mpv process hanging my app and not exiting properly.  I'm hoping that if this isn't merged, similar functionality will be brought in to handle this issue.