### PR TITLE
Replaced dependency cuid by uuid

### DIFF
--- a/lib/mpv/_commands.js
+++ b/lib/mpv/_commands.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const cuid    = require('cuid');
+const uuidV4   = require('uuid/v4');
 
 const commands = {
 	// will send a get request for the specified property
@@ -14,7 +14,7 @@ const commands = {
 		// when no id was set use the promise way
 		else{
 			// request Id
-			let requestId = cuid()
+			let requestId = uuidV4()
 
 			return new Promise(function(resolve, reject) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-mpv",
+  "version": "1.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "homepage": "https://github.com/00SteinsGate00/Node-MPV#readme",
   "dependencies": {
-    "cuid": "^1.3.8"
+    "uuid": "^3.2.1"
   }
 }


### PR DESCRIPTION
Much smaller (85Kb instead of 2.3Mb)

Note : I used v4 (the random one) but v1 (the timestamp version) could be used instead. Feel free to check out the documentation : https://github.com/kelektiv/node-uuid