### PR TITLE
Fixes formatOptions in case several = characters are present (refs #41)

### DIFF
--- a/lib/ipcInterface/_events.js
+++ b/lib/ipcInterface/_events.js
@@ -55,7 +55,7 @@ const events = {
 			if(message.length > 0){
 				const JSONmessage = JSON.parse(message);
 				// if there was a request_id it was a request message
-				if('request_id' in JSONmessage){
+				if(JSONmessage.request_id && JSONmessage.request_id !== 0){
 					// resolve promise
 				 	if(JSONmessage.error === 'success'){
 						// resolve the request

--- a/lib/util.js
+++ b/lib/util.js
@@ -232,7 +232,8 @@ const util = {
 		let splitted = []
 		// iterate through every options
 		for(let i = 0; i < options.length; i++){
-			splitted = options[i].split('=')
+			// Splits only on the first = character
+			splitted = options[i].split(/=(.+)/)
 			optionJSON[splitted[0]] = splitted[1]
 		}
 		return optionJSON;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mpv",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "A Node module for MPV",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/00SteinsGate00/Node-MPV.git"
+    "url": "git+https://github.com/AxelTerizaki/Node-MPV.git"
   },
   "keywords": [
     "mpv",
@@ -18,6 +18,9 @@
     "multimedia"
   ],
   "author": "Jan Holub",
+  "contributors": [
+	  "GuillaumeLebigot (@AxelTerizaki) <axel@teri-chan.net>"
+  ],
   "licenses": [
     {
       "type": "MIT",
@@ -27,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/00SteinsGate00/Node-MPV/issues"
   },
-  "homepage": "https://github.com/00SteinsGate00/Node-MPV#readme",
+  "homepage": "https://github.com/AxelTerizaki/Node-MPV/tree/Node-MPV-2",
   "dependencies": {
     "cuid": "^2.1.1"
   }

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,12 @@ Works on **UNIX** and **Windows**.
 
 **For streaming playback from sources such as YouTube and SoundCloud [youtube-dl](https://github.com/rg3/youtube-dl) is required**
 
+## This fork
+
+This fork includes these specific fixes :
+
+- Fix for IPCRequestID exception when using latest version of mpv (at least 0.29 git version from August 2019, may also affect earlier versions)
+- Fix formatOptions in case several = characters are present in options parameters when loading up files
 
 ## Important
 
@@ -106,7 +112,7 @@ You can optionally pass a JSON object with options to the constructor. Possible 
     "auto_restart": true,
     "binary": null,
     "debug": false,
-    "ipcCommand": null,   
+    "ipcCommand": null,
     "socket": "/tmp/node-mpv.sock", // UNIX
     "socket": "\\\\.\\pipe\\mpvserver", // Windows
     "time_update": 1,
@@ -464,7 +470,7 @@ someAsyncFunction = asnyc () => {
   Adds an audio file to the video that is loaded.
   * `file` The audio file to load
   * `flag` *(optional)* Can be one of "select" (default), "auto" or "cached"
-  * `title` *(optional)* The name for the audio track in the UI  
+  * `title` *(optional)* The name for the audio track in the UI
   * `lang` *(optional)* the language of the audio track
 
   `flag` has the following effects
@@ -554,7 +560,7 @@ someAsyncFunction = asnyc () => {
   Adds a subtitle file to the video that is loaded.
   * `file` The subtitle file to load
   * `flag` *(optional)* Can be one of "select" (default), "auto" or "cached"
-  * `title` *(optional)* The name for the subtitle file in the UI  
+  * `title` *(optional)* The name for the subtitle file in the UI
   * `lang` *(optional)* The language of the subtitle
 
   `flag` has the following effects
@@ -663,7 +669,7 @@ The most common commands are already covered by this modules **API**. This part 
 
 ## Observing
 
-  **node-mpv** allows you to observe any property the [mpv API](https://mpv.io/manual/stable/#property-list) offers you, by simply using the **observeProperty** function.  
+  **node-mpv** allows you to observe any property the [mpv API](https://mpv.io/manual/stable/#property-list) offers you, by simply using the **observeProperty** function.
 
  * **observeProperty** (property, id)
 


### PR DESCRIPTION
TL;DR : 

When using a lavfi-filter option on mpv, you need to pass several sub-options. These sub-options are also defined by `=` character, which means a simple split by `=` wouldn't work.

Instead, I replaced that split by a split on only the first `=`.

Here's how the option string looked initially, you'll understand easily why it didn't work with the former split line : 

```lavfi-complex=movie=\'D:/perso/karaokemugen-app/app/temp/qrcode.png\'[logo];[logo][vid1]scale2ref=192:192[logo1][base];[base][logo1]overlay=28:16[vo] ```

Note that I had to remove `"` from my initial option line for it to work. Before https://github.com/00SteinsGate00/Node-MPV/commit/a8bbcb5de07f868e9686de706780e77af83e9302 it worked with this : 

```lavfi-complex="movie=\'D:/perso/karaokemugen-app/app/temp/qrcode.png\'[logo];[logo][vid1]scale2ref=192:192[logo1][base];[base][logo1]overlay=28:16[vo]"``` 

because the string was sent as is, and not formatted into JSON (it didn't go through `util/formatOption`)

I don't think there would be any side effects, and it allows `formatOptions` to work with more complex options in mpv.
