### PR TITLE
Fix for IPCRequest ID when using latest version (git) of mpv

### DIFF
--- a/lib/ipcInterface/_events.js
+++ b/lib/ipcInterface/_events.js
@@ -55,7 +55,7 @@ const events = {
 			if(message.length > 0){
 				const JSONmessage = JSON.parse(message);
 				// if there was a request_id it was a request message
-				if('request_id' in JSONmessage){
+				if(JSONmessage.request_id && JSONmessage.request_id !== 0){
 					// resolve promise
 				 	if(JSONmessage.error === 'success'){
 						// resolve the request


### PR DESCRIPTION
In mpv's latest iterations (at least as of this commit's date, perhaps
it happens before), request_id is always present in requests when data
is null and contains 0.

Before the property just did not exist.

It caused an uncaught exception as it could not find the IPC Request ID
in the IPCRequest instance.