### PR TITLE
Fixes formatOptions in case several = characters are present (refs #41)

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -232,7 +232,8 @@ const util = {
 		let splitted = []
 		// iterate through every options
 		for(let i = 0; i < options.length; i++){
-			splitted = options[i].split('=')
+			// Splits only on the first = character
+			splitted = options[i].split(/=(.+)/)
 			optionJSON[splitted[0]] = splitted[1]
 		}
 		return optionJSON;


### PR DESCRIPTION
See #50 for more information. This PR only includes the relevant commit fixing this issue, sorry for the mixup.