### PR TITLE
fixes 2 issues that prevented start() from resolving.

### DIFF
--- a/lib/mpv/_startStop.js
+++ b/lib/mpv/_startStop.js
@@ -25,9 +25,9 @@ const startStop = {
 			return this.running ? reject(this.errorHandler.errorMessage(6, 'start()')) : resolve();
 		})
 		// check if the binary is actually available
-		.then(() => {return util.checkMpvBinary(this.options.binary)})
+		.then(() => util.checkMpvBinary(this.options.binary))
 		// check for the corrrect ipc command
-		.then(() => {return util.findIPCCommand(this.options)})
+		.then(() => util.findIPCCommand(this.options))
 		// check if mpv could be started succesffuly
 		.then((ipcCommand) => {
 			return new Promise((resolve, reject) => {
@@ -35,32 +35,33 @@ const startStop = {
 				this.mpv_arguments.push(ipcCommand+'='+this.options.socket);
 				// Spawns the mpv player
 				this.mpvPlayer = spawn((this.options.binary ? this.options.binary : 'mpv'), this.mpv_arguments);
-
-				// Listens to stdout to see, if MPV could bind the IPC socket
-				this.mpvPlayer.stdout.on('data', (data) => {
-					// stdout output
+				// Listen to stdout + stderr to see, if MPV could bind the IPC socket
+				var stdCallback = (data) => {
+					// stdout/stderr output
 					const output = data.toString();
-
 					// "Listening to IPC socket" - message
-					if(output.match(/Listening to IPC socket/)){
+					if(output.match(/Listening to IPC (socket|pipe)/)){
 						// remove the event listener on stdout
+						this.mpvPlayer.stderr.removeAllListeners('data');
 						this.mpvPlayer.stdout.removeAllListeners('data');
 						resolve();
 					}
 					// "Could not bind IPC Socket" - message
-					else if(output.match(/Could not bind IPC socket/)){
+					else if(output.match(/Could not bind IPC (socket|pipe)/)){
 						// remove the event listener on stdout
+						this.mpvPlayer.stderr.removeAllListeners('data');
 						this.mpvPlayer.stdout.removeAllListeners('data');
 						reject(this.errorHandler.errorMessage(4, 'startStop()', [this.options.socket]));
 					}
-				});
+				};
+				this.mpvPlayer.stdout.on('data', stdCallback);
+				this.mpvPlayer.stderr.on('data', stdCallback);
 			});
 		})
 		.then(() => {
 			return new Promise((resolve, reject) => {
 				// Set up the socket connection
 				this.socket.connect(this.options.socket);
-				
 				// socket to check for the idle event to check if mpv fully loaded and
 				// actually running
 				const observeSocket = net.Socket();
@@ -68,22 +69,22 @@ const startStop = {
 					// parse the messages from the socket
 					const messages = data.toString('utf-8').split('\n');
 					// check every message
-					messages.forEach((message) => {
+					for (var message of messages) {
 						// ignore empty messages
 						if(message.length > 0){
 							message = JSON.parse(message);
 							// console.log(message);
-							if('event' in message && message.event === 'idle'){
+							if('event' in message && ['idle','file-loaded'].indexOf(message.event)!==-1){
 								observeSocket.destroy();
-								resolve();
+								return resolve();
 							}
 						}
-					});
+					}
 				});
 			});
 		})
 		// If the promise was resolved continue initializing the socket communication
-		.then(() => {			
+		.then(() => {
 			// sets the Interval to emit the current time position
 			this.observeProperty('time-pos', 0);
 			this.timepositionListenerId = setInterval(() => {


### PR DESCRIPTION
- One where piped --o requires listening to stderr instead of stdout (and listening for slightly different message)
- When files are added as command line arguments, the 'idle' event never fired, so we now listen for 'file-loaded' as well, just in case.