### PR TITLE
Add a stimulus to start function/Update events (idle -> idle-active)

### DIFF
--- a/lib/mpv/_startStop.js
+++ b/lib/mpv/_startStop.js
@@ -118,7 +118,13 @@ const startStop = {
 				// socket to check for the idle event to check if mpv fully loaded and
 				// actually running
 				const observeSocket = net.Socket();
-				observeSocket.connect({path: this.options.socket}).on('data', (data) => {
+				observeSocket.connect({path: this.options.socket}, () => {
+					// send any message to see if there's a MPV instance responding
+					observeSocket.write(JSON.stringify({
+						'command': ['get_property', 'idle-active']
+					})+'\n');
+					if (this.options.debug || this.options.verbose) console.log('[Node-MPV] sending stimulus');
+				}).on('data', (data) => {
 					// parse the messages from the socket
 					const messages = data.toString('utf-8').split('\n');
 					// check every message
@@ -127,13 +133,21 @@ const startStop = {
 						if(message.length > 0){
 							message = JSON.parse(message);
 							// check for the relevant events to see, if mpv has finished loading
-							// idle
+							// idle, idle-active (different between mpv versions)
 							//     usually if no special options were added and mpv will go into idle state
 							// file-loaded
 							//     for the rare case that somebody would pass files as input via the command line
 							//     through the constructor. In that case mpv never goes into idle mode
-							if('event' in message && ['idle','file-loaded'].includes(message.event)){
+							if('event' in message && ['idle','idle-active','file-loaded'].includes(message.event)){
+								if (this.options.debug || this.options.verbose) console.log('[Node-MPV] idling');
 								observeSocket.destroy();							
+								resolve();
+							}
+							// check our stimulus response
+							// Check for our stimulus with idle-active
+							if('data' in message && 'error' in message && message.error === 'success') {
+								if (this.options.debug || this.options.verbose) console.log('[Node-MPV] stimulus received', message.data);
+								observeSocket.destroy();
 								resolve();
 							}
 						}
@@ -160,7 +174,13 @@ const startStop = {
 		// sets the Interval to emit the current time position
 		this.observeProperty('time-pos', 0);
 		this.timepositionListenerId = setInterval(async () => {
-			const paused = await this.isPaused();
+			const paused = await this.isPaused().catch(err => {
+				if (this.options.debug) console.log('[Node-MPV] timeposition listener cannot retrieve isPaused', err);
+				if (err.code === 8) { // mpv is not running but the interval was not cleaned out
+					clearInterval(this.timepositionListenerId);
+					return true;
+				} else throw err; // This error is not catcheable, maybe provide a function in options to catch these
+			});
 			// only emit the time position if there is a file playing and it's not paused
 			if(!paused && this.currentTimePos != null){
 				this.emit("timeposition", this.currentTimePos);

--- a/lib/util.js
+++ b/lib/util.js
@@ -190,10 +190,9 @@ const util = {
 
 		// default Arguments
 		// --idle always run in the background
-		// --really-quite  no console prompts. Buffer might overflow otherwise
-		// --msg-level=ipc=v  sets IPC socket related messages to verbose
-		let defaultArgs = ['--idle', '--really-quiet', '--msg-level=ipc=v'];
-
+		// --msg-level=all=no,ipc=v  sets IPC socket related messages to verbose and
+		// silence all other messages to avoid buffer overflow
+		let defaultArgs = ['--idle', '--msg-level=all=no,ipc=v'];
 		//  audio_only option aditional arguments
 		// --no-video  no video will be displayed
 		// --audio-display  prevents album covers embedded in audio files from being displayed


### PR DESCRIPTION
Closes #79 by sending a [stimulus](https://github.com/j-holub/Node-MPV/pull/81/files#diff-a17d1dd2cb3b1a8f8ccd3dc5b05102dbR123) to test the socket (we can imagine a loop to wait for idle-active to be true).

The error event may be useful to configure on the timeposition intervalled function, related to #78 
You can also make the possibility to pass an error handler in options