### PR TITLE
Support all protocols that mpv supports, not just html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `load()`, `append()`, `loadPlaylist()`, `prev()` and `next()` are a lot more robust and check if the file or stream could be played or not
   * Added the possibility to hook into a running instance of **mpv**
   * `start()` can also take mpv arguments
+  * Support any protocol that **mpv** supports
   * `mute()`, `unmute()` and `toggleMute()` are now one function `mute()` that can take a boolean as an argument
   * `loop()` can now also toggle the mute state by not passing an argument
   * `loopPlaylist()` and `clearLoopPlaylist()` were combined into `loopPlaylist()`, which works exactly as `loop()`

--- a/lib/error.js
+++ b/lib/error.js
@@ -26,7 +26,8 @@ const ErrorHandler = class {
 			5: 'Timeout',
 			6: 'MPV is already running',
 			7: 'Could not send IPC message',
-			8: 'MPV is not running'
+			8: 'MPV is not running',
+			9: 'Unsupported protocol'
 		}
 	}
 

--- a/lib/mpv/mpv.js
+++ b/lib/mpv/mpv.js
@@ -96,7 +96,19 @@ mpv.prototype = Object.assign({
 		// MPV accepts various protocols, but the all start with <protocol>://, leave this input as it is
 		// if it's a file, transform the path into the absolute filepath, such that it can be played
 		// by any mpv instance, started in any working directory
-		source = source.includes('://') ? source : path.resolve(source);
+		// also checks if the protocol is supported by mpv and throws an error otherwise
+		const sourceProtocol = util.extractProtocolFromSource(source);
+		if (sourceProtocol && !util.validateProtocol(sourceProtocol)) {
+			throw (
+				this.errorHandler.errorMessage(
+					9,
+					caller,
+					options ? [source, mode].concat(options) : [source, mode],
+					null,
+					'See https://mpv.io/manual/stable/#protocols for supported protocols')
+			);
+		}
+		source = sourceProtocol ? source : path.resolve(source);
 
 		await new Promise ((resolve, reject) => {
 			// socket to observe the command

--- a/lib/mpv/mpv.js
+++ b/lib/mpv/mpv.js
@@ -93,11 +93,10 @@ mpv.prototype = Object.assign({
 			);
 		}
 
-		// if the source is a URI, leave it as it is. MPV only accepts HTTP URIs, so checking
-		// if http is included is sufficient
+		// MPV accepts various protocols, but the all start with <protocol>://, leave this input as it is
 		// if it's a file, transform the path into the absolute filepath, such that it can be played
 		// by any mpv instance, started in any working directory
-		source = source.includes('http') ? source : path.resolve(source);
+		source = source.includes('://') ? source : path.resolve(source);
 
 		await new Promise ((resolve, reject) => {
 			// socket to observe the command

--- a/lib/util.js
+++ b/lib/util.js
@@ -242,6 +242,46 @@ const util = {
 		const stackMatch  = new Error().stack.match(/at\s\w*[^getCaller]\.\w*\s/g);
 		const caller = stackMatch[stackMatch.length-1].split('.')[1].trim() + '()'
 		return caller;
+	},
+	// extracts the protocol from a source string,e.g. http://someurl.com returns http
+	// returns null if no protocol was found
+	// @param source
+	// 		source string
+	// 
+	// @return
+	// 		protocol string
+	extractProtocolFromSource: function ( source ) {
+		return !source.includes('://') ? null : source.split('://')[0];
+	},
+	// checks if a given protocol is supported 
+	// @param protocol
+	// 		protocol string, e.g. "http"
+	// 
+	// @returns
+	// 		boolean if the protocol is supported by mpv
+	validateProtocol: function( protocol ) {
+		return [
+			"appending",
+			"av",
+			"bd",
+			"cdda",
+			"dvb",
+			"dvd",
+			"edl",
+			"fd",
+			"fdclose",
+			"file",
+			"hex",
+			"http",
+			"https",
+			"lavf",
+			"memory",
+			"mf",
+			"null",
+			"slice",
+			"smb",
+			"ytdl"
+		].includes(protocol);
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -269,7 +269,7 @@ Since it is not possible to determine if an **MPV** instance, that has been star
 
  * **load** (content, mode="replace", options)
 
-    Will load the `content` (either a **file** or a **url**) and start playing it. This behaviour can be changed using the `mode`  option
+    Will load the `content` (either a **file**, a **url** or any [supported protocol](https://mpv.io/manual/stable/#protocols)) and start playing it. This behaviour can be changed using the `mode`  option.
 
     * `mode`
     * `replace`*(default)* replace the current title and play it immediately


### PR DESCRIPTION
I wasn't aware that MPV actually supports a ton of different protocols besides HTML, but @oliveirapedroma pointed this out to me in #86.

If this works, I might think about verifying, that the input protocol is actually supported by MPV and reject the promise with an error message otherwise.

Please see if this change works you @oliveirapedroma.