### PR TITLE
Added optional `mpv_args` argument to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -632,7 +632,7 @@ export default class NodeMpv implements EventEmitter {
 	/**
 	 * Starts mpv, by spawning a child process or by attaching to existing socket
 	 */
-	start(): Promise<void>;
+	start(mpv_args?: Array<string|number>): Promise<void>;
 	/**
 	 * Closes mpv
 	 *


### PR DESCRIPTION
Fixes an issue where typescript will complain about providing the mpv_args argument on the Node_MPV.start() method

----

To give you some context, projects that were not written in TypeScript can still provide an index.d.ts file. This way, TypeScript can interpret the expected input and output for every function you expose in node-mpv.

However, there was a mistake in the type definition for the Node_MPV.start method.

Take a look at this snippet and the typescript error it causes:
![image](https://user-images.githubusercontent.com/35025484/140099474-8b3ac77e-c454-463b-8b30-8ad7db58e6a8.png)

It says 0 arguments are expected in this function, but clearly in _StartStop.js, you defined an optional array argument `mpv_args`:

```javascript
	// Starts the MPV player process
	//
	// After MPV is started the function listens to the spawned MPV child proecesses'
	// stdout for see whether it could create and bind the IPC socket or not.
	// If possible an ipcInterface is created to handle the socket communication
	//
	// Observes the properties defined in the observed object
	// Sets up the event handlers
	// 
	// mpv_args
	// 	arguments that are passed to mpv on start up
	//
	// @return
	// Promise that is resolved when everything went fine or rejected when an
	// error occured
	//
	start:  async function (mpv_args = []) {
```

This `mpv_args` is missing from the index.d.ts file on L635:
```javascript
	start(): Promise<void>;
```

Hence, this PR. I changed only the type definition:
```javascript
	start(mpv_args?: Array<string|number>): Promise<void>;
```

- mpv_args is the name of the optional argument, the same as in the actual function.
- the question mark is a typescript thing and it indicates that the argument is optional. More specifically, this means that the mpv_args argument for this function can either be undefined or `Array<string|number>`
- Array<string|number> means that if the argument is provided, it has to be an array. And if the array has elements, they have to be either a string or a number.

Hope this is clear, and close enough to what your function actually expects.